### PR TITLE
Improved user plan handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All Notable changes to this package` will be documented in this file
 
+## Version 1.4
+
+- Significant refactor. The 2nd argument for the `plan()` helper function now allows for passing a $user object.
+- Removed the following methods
+    - **getPlanOfUser**
+    - **getUserPlan**
+    - **getAllowedOverrides**
+    - **getPlanOverrides**
+
 ## Version 1.3
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     },
     "require-dev": {
         "mockery/mockery": "dev-master@dev",
-        "phpunit/phpunit": "~4.1"
+        "phpunit/phpunit": "~4.1",
+        "orchestra/testbench": "^3.2"
     },
     "autoload": {
         "psr-4": {

--- a/readme.md
+++ b/readme.md
@@ -97,6 +97,16 @@ If your user is subscribed to the silver plan, they could only add 10 widgets. Y
 ]
 ```
 
+
+#### Get a Plan's Config Without the User
+
+In the case where a specific plan config is needed, you can pass in the plan's code as a string for the 2nd argument:
+
+```
+plan('limits.widgets', 'bronze'); // Returns 5
+plan('limits.widgets', 'silver'); // Returns 10
+```
+
 # Configuring Your Plans
 
 To configure your plans, open up app/plans.php and start adding your plan details. By default the package assumes that you're using laravel's built in Auth, and that the user's plan is stored in the User model. You can set the field used to determine the user's plan in the config...
@@ -229,11 +239,14 @@ In the above example, you would create the *plan_overrides* attribute on the use
 
 Would result in the following...
 
-|  Key | Call | Result | Overridden? |
-| --- | --- | --- | --- |
-| limits.widgets | `plan('limits.widgets');` | **10** | No |
-| limits.apples | `plan('limits.apples');` | **50** | Yes |
-| limits.bananas | `plan('limits.bananas');` | **100** | Yes |
+|  User's Plan | Key | Call | Result | Overridden? |
+| --- | --- | --- | --- | --- |
+| silver | limits.widgets | `plan('limits.widgets');` | **10** | No |
+| silver | limits.apples | `plan('limits.apples');` | **50** | Yes |
+| silver | limits.bananas | `plan('limits.bananas');` | **100** | Yes |
+| silver | limits.bananas | `plan('limits.bananas', 'silver')` | 20 | No |
+| bronze | limits.bananas | `plan('limits.bananas', 'silver')` | 20 | No |
+| bronze | limits.bananas | `plan('limits.bananas', $user)` | 100 | Yes |
 
 
 # Why I created this

--- a/src/functions.php
+++ b/src/functions.php
@@ -5,10 +5,10 @@ if ( ! function_exists('plan')) {
 
     /**
      * @param $key
-     * @param string $plan
+     * @param string|array|object $plan
      * @return mixed
      */
-    function plan($key, $plan = '')
+    function plan($key, $plan = null)
     {
         $planConfig = app('planconfig');
 


### PR DESCRIPTION
- Updated the way the plan key/value lookup works. If a user object or array is passed instead of the plan code, then the result will factor in the user’s specific plan overrides (if any)
- Added orchestra/testbench to assist with testing
- Added tests for helper function plan()